### PR TITLE
Test vercel fail deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "@testing-library/user-event": "^7.1.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-scripts": "3.4.3"
+    "react-scripts": "3.4.3",
+    "@test-app/A": "link:./packages/A",
+    "@test-app/B": "link:./packages/B"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/packages/A/index.js
+++ b/packages/A/index.js
@@ -1,0 +1,1 @@
+module.exports = "I'm package A"

--- a/packages/B/index.js
+++ b/packages/B/index.js
@@ -1,0 +1,1 @@
+module.exports = "I'm package B"

--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ function App() {
           <div><code>{A}</code></div>
           <div><code>{B}</code></div>
         </p>
-        <div>1</div>
+        <div>2</div>
       </header>
     </div>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ function App() {
           <div><code>{A}</code></div>
           <div><code>{B}</code></div>
         </p>
-        <div>4</div>
+        <div>5</div>
       </header>
     </div>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ function App() {
           <div><code>{A}</code></div>
           <div><code>{B}</code></div>
         </p>
-        <div>5</div>
+        <div>6</div>
       </header>
     </div>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ function App() {
           <div><code>{A}</code></div>
           <div><code>{B}</code></div>
         </p>
-        <div />
+        <div>1</div>
       </header>
     </div>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ function App() {
           <div><code>{A}</code></div>
           <div><code>{B}</code></div>
         </p>
-        <div>3</div>
+        <div>4</div>
       </header>
     </div>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ function App() {
           <div><code>{A}</code></div>
           <div><code>{B}</code></div>
         </p>
-        <div>2</div>
+        <div>3</div>
       </header>
     </div>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -2,22 +2,18 @@ import React from 'react';
 import logo from './logo.svg';
 import './App.css';
 
+import A from '@test-app/A'
+import B from '@test-app/B'
+
 function App() {
   return (
     <div className="App">
       <header className="App-header">
         <img src={logo} className="App-logo" alt="logo" />
         <p>
-          Edit <code>src/App.js</code> and save to reload.
+          <div><code>{A}</code></div>
+          <div><code>{B}</code></div>
         </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
       </header>
     </div>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ function App() {
           <div><code>{A}</code></div>
           <div><code>{B}</code></div>
         </p>
+        <div />
       </header>
     </div>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ function App() {
           <div><code>{A}</code></div>
           <div><code>{B}</code></div>
         </p>
-        <div>7</div>
+        <div>8</div>
       </header>
     </div>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ function App() {
           <div><code>{A}</code></div>
           <div><code>{B}</code></div>
         </p>
-        <div>6</div>
+        <div>7</div>
       </header>
     </div>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1417,6 +1417,14 @@
     "@svgr/plugin-svgo" "^4.3.1"
     loader-utils "^1.2.3"
 
+"@test-app/A@link:./packages/A":
+  version "0.0.0"
+  uid ""
+
+"@test-app/B@link:./packages/B":
+  version "0.0.0"
+  uid ""
+
 "@testing-library/dom@*":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.22.5.tgz#178fb0bfb52540538667f2f72d4b7fb406a49499"


### PR DESCRIPTION
## Steps to reproduce
- Make any change on this branch. For example, I'm increasing a counter on `src/App.js`.
- Commit and push, this will trigger a build on vercel which will succeed because vercel has probably wiped its internal caches.
- Make another change.
- Commit and push, this will trigger a build on vercel which **will fail**.

## What seems to be happening
The underlying issue seems to be a mix of two behaviors:

- **How vercel internally stores/restores the build cache**: vercel doesn't seem to properly handle symlinks for the cached `node_modules`.
- **How yarn behaves with `link:` dependencies**: `link:` dependencies are not checked by default when running `yarn install`

## Notes
- ❗ If at any point you manually trigger a Redeploy on the vercel dashboard, it will always succeed, because manually triggering it, seems to internally override their node_modules cache.

